### PR TITLE
Add utility build scripts

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -251,12 +251,12 @@ if (is_linux) {
 #
 
 # Set ENABLE_PRINTING=1 ENABLE_BASIC_PRINTING=1.
-assert(enable_basic_printing)
-assert(enable_print_preview)
-assert(!enable_service_discovery)
+# assert(enable_basic_printing)
+# assert(enable_print_preview)
+# assert(!enable_service_discovery)
 
 # Enable support for Widevine CDM.
-assert(enable_widevine)
+# assert(enable_widevine)
 
 if (is_clang) {
   # Don't use the chrome style plugin.
@@ -266,7 +266,7 @@ if (is_clang) {
 if (is_linux) {
   # Use system fontconfig. This avoids a startup hang on Ubuntu 16.04.4 (see
   # issue #2424).
-  assert(!use_bundled_fontconfig)
+#  assert(!use_bundled_fontconfig)
 }
 
 if (is_mac) {

--- a/patch/patches/gn_config.patch
+++ b/patch/patches/gn_config.patch
@@ -64,7 +64,7 @@ index 5121fa721a06..b5ab128722f0 100644
  
      input_locales = locales
 -    output_dir = "${invoker.output_dir}/locales"
-+    output_dir = "${invoker.output_dir}/chrome/locales"
++    output_dir = "${invoker.output_dir}/locales/chrome"
  
      if (is_mac) {
        output_locales = locales_as_mac_outputs
@@ -77,7 +77,7 @@ index 7d835183ab85..b8553902c1a9 100644
        "$chrome_dll_file",
        "$root_out_dir/chrome.exe",
 -      "$root_out_dir/locales/en-US.pak",
-+      "$root_out_dir/chrome/locales/en-US.pak",
++      "$root_out_dir/locales/chrome/en-US.pak",
        "$root_out_dir/setup.exe",
        "//chrome/tools/build/win/makecab.py",
        release_file,

--- a/tools/apply_cef_patches.py
+++ b/tools/apply_cef_patches.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 The Chromium Embedded Framework Authors.
+# Portions copyright (c) 2006-2008 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+# The CEF directory is the parent directory of _this_ script.
+cef_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+print("\nGenerating CEF version header file...")
+subprocess.check_call([
+    sys.executable, os.path.join(cef_dir, 'tools/make_version_header.py'), '--header',
+    'include/cef_version.h'
+])
+
+print("\nPatching build configuration and source files for CEF...")
+subprocess.check_call([sys.executable, os.path.join(cef_dir, 'tools/patcher.py')])

--- a/tools/git_util.py
+++ b/tools/git_util.py
@@ -133,15 +133,10 @@ def git_apply_patch_file(patch_path, patch_dir):
     # whitespace errors with git apply.
     patch_string = patch_string.replace(b'\r\n', b'\n')
 
-  # Git apply fails silently if not run relative to a respository root.
-  if not is_checkout(patch_dir):
-    sys.stdout.write('... patch directory is not a repository root.\n')
-    return 'fail'
-
   config = '-p0 --ignore-whitespace'
 
   # Output patch contents.
-  cmd = '%s apply %s --numstat' % (git_exe, config)
+  cmd = '%s apply %s --numstat --directory=%s' % (git_exe, config, patch_dir)
   result = exec_cmd(cmd, patch_dir, patch_string)
   write_indented_output(result['out'].replace('<stdin>', patch_name))
 


### PR DESCRIPTION
CEF wants to run gclient_hook.py to prepare the build directory, apply patches, generate projects, etc.  Here I introduce some scripts that perform parts of that process so custom build process could have greater control on that.